### PR TITLE
Switch from Test::Stream to Test2::Suite.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -6,5 +6,5 @@ requires 'Carp'                => 0;
 requires 'Config::MethodProxy' => 0.02;
 
 on test => sub {
-    requires 'Test::Stream' => 1.302026;
+    requires 'Test2::Suite' => 0;
 };

--- a/t/build_args.t
+++ b/t/build_args.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-use Test::Stream '-V1';
+use Test2::Bundle::Extended;
 
 {
     package Foo;

--- a/t/build_args_hooks.t
+++ b/t/build_args_hooks.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-use Test::Stream '-V1';
+use Test2::Bundle::Extended;
 
 {
     package Foo;

--- a/t/method_proxy_args.t
+++ b/t/method_proxy_args.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-use Test::Stream '-V1';
+use Test2::Bundle::Extended;
 
 {
     package Foo;

--- a/t/rebuild.t
+++ b/t/rebuild.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-use Test::Stream '-V1';
+use Test2::Bundle::Extended;
 
 {
     package Foo;

--- a/t/single_arg.t
+++ b/t/single_arg.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-use Test::Stream '-V1';
+use Test2::Bundle::Extended;
 
 {
     package Foo;


### PR DESCRIPTION
Hi,

Thanks for writing MooX-BuildArgs!

This is a patch for issue #2, since Test::Stream is pretty much no longer available in some OS's packaging systems, and since it is also deprecated.

Thanks in advance for your time, and keep up the gread work!

G'luck,
Peter
