### PR TITLE
Fix a couple of typographical errors.

### DIFF
--- a/lib/MooX/BuildArgs.pm
+++ b/lib/MooX/BuildArgs.pm
@@ -17,7 +17,7 @@ MooX::BuildArgs - Save instantiation arguments for later use.
 =head1 DESCRIPTION
 
 It is often useful to be able to access the arguments that were
-used to create an object in their unadulturated form, before any
+used to create an object in their unadulterated form, before any
 coercions or init_args have changed them.  This L<Moo> role
 provides the arguments via the L</build_args> attribute.
 

--- a/lib/MooX/BuildArgsHooks.pm
+++ b/lib/MooX/BuildArgsHooks.pm
@@ -38,7 +38,7 @@ MooX::BuildArgsHooks - Structured BUILDARGS.
 =head1 DESCRIPTION
 
 This module installs some hooks directly into L<Moo> which allow
-for more fine-grained access to the phases of C<BUILDLARGS>.  The
+for more fine-grained access to the phases of C<BUILDARGS>.  The
 reason this is important is because if you have various roles and
 classes modifying BUILDARGS you will often end up with weird
 behaviors depending on what order the various BUILDARGS wrappers
@@ -144,7 +144,7 @@ BEGIN {
 # Must declare a custom no-op BUILDARGS otherwise
 # Method::Generate::Constructor gets in the way.
 # Alternatively we could modify its inlined BUILDARGS
-# to include our logic, but thats making things even
+# to include our logic, but that's making things even
 # more brittle.
 around BUILDARGS => sub{
     my $orig = shift;

--- a/lib/MooX/MethodProxyArgs.pm
+++ b/lib/MooX/MethodProxyArgs.pm
@@ -26,7 +26,7 @@ MooX::MethodProxyArgs - Invoke code to populate static arguments.
 
 =head1 DESCRIPTION
 
-This module munges the class's input arugments by replacing any
+This module munges the class's input arguments by replacing any
 method proxy values found with the result of calling the methods.
 
 This is done using L<Config::MethodProxy>.  See that module for more


### PR DESCRIPTION
Hi,

Here's a minor patch that fixes a couple of misspellings.

Thanks again for your work on MooX-BuildArgs and all the other modules!

G'luck,
Peter
