### PR TITLE
Let the proxy args test pass on recent versions of Perl.

### DIFF
--- a/t/method_proxy_args.t
+++ b/t/method_proxy_args.t
@@ -8,6 +8,8 @@ use Test2::Bundle::Extended;
     has bar => ( is=>'ro' );
 }
 
+$INC{'main.pm'} = 1;
+
 sub divide {
     my ($class, $number, $divisor) = @_;
     return $number / $divisor;


### PR DESCRIPTION
Use the $INC{...} = 1 trick to fool Perl into thinking main.pm has
also been loaded at some point.

This makes the test pass at least on Debian testing with Perl 5.24.1.

Thanks in advance, and keep up the great work!

G'luck,
Peter
